### PR TITLE
CI: parametrize the conda env name to match the repo name

### DIFF
--- a/.github/workflows/test-conda-pack-packages.yml
+++ b/.github/workflows/test-conda-pack-packages.yml
@@ -14,12 +14,18 @@ jobs:
       fail-fast: false
 
     steps:
+      - name: Set env.REPOSITORY_NAME  # just the repo, as opposed to org/repo
+        shell: bash -l {0}
+        run: |
+          export REPOSITORY_NAME=${GITHUB_REPOSITORY#*/}
+          echo "REPOSITORY_NAME=${REPOSITORY_NAME}" >> $GITHUB_ENV
+
       - name: checkout the code
         uses: actions/checkout@v2
 
       - uses: conda-incubator/setup-miniconda@v2
         with:
-          activate-environment: "conda-pack"
+          activate-environment: ${{ env.REPOSITORY_NAME }}
           auto-update-conda: true
           miniconda-version: "latest"
           python-version: ${{ matrix.python-version }}


### PR DESCRIPTION
This update is to make the Github Actions CI configuration a bit more portable.