### PR TITLE
Better YAML processing

### DIFF
--- a/.github/workflows/test-conda-pack-packages.yml
+++ b/.github/workflows/test-conda-pack-packages.yml
@@ -20,6 +20,12 @@ jobs:
           export REPOSITORY_NAME=${GITHUB_REPOSITORY#*/}
           echo "REPOSITORY_NAME=${REPOSITORY_NAME}" >> $GITHUB_ENV
 
+      - name: Set secrets
+        shell: bash -l {0}
+        run: |
+          export ZENODO_ACCESS_TOKEN=${{ secrets.ZENODO_ACCESS_TOKEN }}
+          echo "ZENODO_ACCESS_TOKEN=${ZENODO_ACCESS_TOKEN}" >> $GITHUB_ENV
+
       - name: checkout the code
         uses: actions/checkout@v2
 

--- a/configs/n2sn.yml
+++ b/configs/n2sn.yml
@@ -5,7 +5,10 @@ pkg_name: "n2snusertools"
 pkg_version: &version "0.3.6"
 extra_packages: ""
 channels: "-c nsls2forge -c defaults"
-docker_upload: "ghcr;dockerhub;quay"
+docker_upload:
+  - ghcr
+  - dockerhub
+  - quay
 zenodo_metadata:
   metadata:
     title: "User tools for the NSLS-II Science Network"

--- a/configs/n2sn.yml
+++ b/configs/n2sn.yml
@@ -2,7 +2,7 @@ docker_image: "quay.io/condaforge/linux-anvil-comp7:latest"
 env_name: "n2sn"
 python_version: "3.9.4"
 pkg_name: "n2snusertools"
-pkg_version: "0.3.6"
+pkg_version: &version "0.3.6"
 extra_packages: ""
 channels: "-c nsls2forge -c defaults"
 docker_upload: "ghcr;dockerhub;quay"
@@ -11,7 +11,7 @@ zenodo_metadata:
     title: "User tools for the NSLS-II Science Network"
     upload_type: "software"
     description: "User tools for the NSLS-II Science Network. https://github.com/NSLS-II/N2SNUserTools"
-    version: "0.3.6"
+    version: *version
     creators:
       - name: Gedell, John
         affiliation: "St. Joseph's College"

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ conda-pack
 ipython
 jinja2
 pyyaml
+requests

--- a/templates/runner.sh.j2
+++ b/templates/runner.sh.j2
@@ -68,5 +68,5 @@ exit 1
 {% endif -%}
 {% endfor -%}
 {%- if zenodo_upload == "yes" %}
-python3 zenodo_uploader.py -f ${env_name}.tar.gz -c configs/${env_name}.yml
+python3 zenodo_uploader.py -f ${artifacts_dir}/${env_name}.tar.gz -c configs/${env_name}.yml
 {% endif %}

--- a/templates/runner.sh.j2
+++ b/templates/runner.sh.j2
@@ -68,5 +68,5 @@ exit 1
 {% endif -%}
 {% endfor -%}
 {%- if zenodo_upload == "yes" %}
-# python3 zenodo_uploader.py -f ${env_name}.tar.gz
+python3 zenodo_uploader.py -f ${env_name}.tar.gz -c configs/${env_name}.yml
 {% endif %}

--- a/templates/runner.sh.j2
+++ b/templates/runner.sh.j2
@@ -40,7 +40,7 @@ else
     ${docker_run_cmd}
 fi
 
-{%- for key in docker_upload.split(";") %}
+{%- for key in docker_upload %}
 {% if key == "ghcr" %}
 # echo $GITHUB_TOKEN | docker login ghcr.io --username $GITHUB_USERNAME --password-stdin
 # docker tag ${env_name}:${timestamp} ghcr.io/$GITHUB_USERNAME/${env_name}:${timestamp}


### PR DESCRIPTION
## Summary of changes
- Added Zenodo uploading step to the `runner.sh.j2` template.
- Added `ZENODO_ACCESS_TOKEN` for https://sandbox.zenodo.org to the repo's settings and changed the CI configuration accordingly.
- Improved the YAML configuration handling:
  - used YAML lists for the `docker_upload` key and changed the code accordingly;
  - used YAML anchors to avoid duplication of the version information.
- Added a missing `requests` requirement.

### Helpful resources
Articles that helped to use anchors in YAML:
- https://support.atlassian.com/bitbucket-cloud/docs/yaml-anchors/
- https://stackoverflow.com/questions/2063616/how-to-reference-a-yaml-setting-from-elsewhere-in-the-same-yaml-file

## Results

The CI now performs and automated uploading of the `.tar.gz` artifact to https://sandbox.zenodo.org, here is an example upload to https://sandbox.zenodo.org/record/889982 (see the [build log](https://github.com/NSLS-II/conda-pack-template/runs/3198479851?check_suite_focus=true#step:10:1082) for the link output)

![image](https://user-images.githubusercontent.com/13209176/127598088-5e21ed78-baa3-46e2-a78d-2aa513b76710.png)
