### PR TITLE
fix defaults for docker_upload, handle zenodo_metadata better

### DIFF
--- a/render.py
+++ b/render.py
@@ -23,9 +23,12 @@ if __name__ == "__main__":
 
     with open(config_file) as f:
         params = yaml.load(f, Loader=yaml.SafeLoader)
-    params.setdefault('docker_upload', "dockerhub;ghcr;quay")
-    params.setdefault('zenodo_upload', "yes")
-    params.pop('zenodo_metadata')  # removing the parameters that are not needed for rendering
+    params.setdefault('docker_upload', ['dockerhub', 'ghcr', 'quay'])
+    zenodo_metadata_present = params.pop(
+        'zenodo_metadata', None
+    )  # removing the parameters that are not needed for rendering
+    if zenodo_metadata_present:
+        params.setdefault('zenodo_upload', 'yes')
 
     script_location = os.path.abspath(os.path.dirname(__file__))
     templates_dir = os.path.join(script_location, 'templates')


### PR DESCRIPTION
these changes fix a KeyError if zenodo_metadata is not defined, and produce what is probably the intended output of the docker_upload default option, which is to render all 3 options