### PR TITLE
`n2sn` with packages from conda forge

### DIFF
--- a/configs/n2sn.yml
+++ b/configs/n2sn.yml
@@ -1,10 +1,10 @@
 docker_image: "quay.io/condaforge/linux-anvil-comp7:latest"
 env_name: "n2sn"
-python_version: "3.9.4"
+python_version: "3.9"
 pkg_name: "n2snusertools"
 pkg_version: &version "0.3.6"
-extra_packages: ""
-channels: "-c nsls2forge -c defaults"
+extra_packages: "krb5 python-gssapi"
+channels: "-c conda-forge"
 docker_upload:
   - ghcr
   - dockerhub


### PR DESCRIPTION
Added missing dependencies of `krb5` and `python-gssapi`.

Based on commits from #20, will rebase once that PR is merged.

Published at https://zenodo.org/record/5182385.