### PR TITLE
nsls2-collection-2021-2.2

### DIFF
--- a/.github/workflows/test-conda-pack-nsls2-collection.yml
+++ b/.github/workflows/test-conda-pack-nsls2-collection.yml
@@ -67,18 +67,18 @@ jobs:
         run: |
           # For reference: https://www.gnu.org/software/bash/manual/html_node/The-Set-Builtin.html.
           set -vxeuo pipefail
-          python3 render.py -c configs/nsls2-collection.yml -f Dockerfile.j2
-          python3 render.py -c configs/nsls2-collection.yml -f runner.sh.j2
+          dockerfile=$(python3 render.py -c configs/nsls2-collection.yml -f Dockerfile.j2)
+          runner=$(python3 render.py -c configs/nsls2-collection.yml -f runner.sh.j2)
           ls -la
-          cat ./Dockerfile
-          cat ./runner-nsls2-collection-2021-2.1.sh
+          cat ${dockerfile}
+          cat ${runner}
 
       - name: run a build with Docker
         shell: bash -l {0}
         run: |
           # For reference: https://www.gnu.org/software/bash/manual/html_node/The-Set-Builtin.html.
           set -vxeuo pipefail
-          bash ./runner-nsls2-collection-2021-2.1.sh
+          bash ./runner-nsls2-collection-2021-2.2.sh
           ls -laF
           sudo chown -v $USER: artifacts/*
           ls -laF artifacts/

--- a/.github/workflows/test-conda-pack-nsls2-collection.yml
+++ b/.github/workflows/test-conda-pack-nsls2-collection.yml
@@ -26,6 +26,15 @@ jobs:
           export ZENODO_ACCESS_TOKEN=${{ secrets.ZENODO_ACCESS_TOKEN }}
           echo "ZENODO_ACCESS_TOKEN=${ZENODO_ACCESS_TOKEN}" >> $GITHUB_ENV
 
+      - name: Set non-secret environment variables
+        shell: bash -l {0}
+        run: |
+          # ZENODO_OWNER_ID is an integer number corresponding to the sandbox
+          # account with the token above, that is used to upload files, and to
+          # search by the owner id.
+          export ZENODO_OWNER_ID="40261"  # mrakitin's owner id on sandbox.zenodo.org
+          echo "ZENODO_OWNER_ID=${ZENODO_OWNER_ID}" >> $GITHUB_ENV
+
       - name: checkout the code
         uses: actions/checkout@v2
 

--- a/configs/nsls2-collection-py39.yml
+++ b/configs/nsls2-collection-py39.yml
@@ -1,6 +1,6 @@
 docker_image: "quay.io/condaforge/linux-anvil-comp7:latest"
-env_name: "nsls2-collection-2021-2.1-py39"
-conda_env_file: "nsls2-collection-2021-2.1-py39-env.yml"
+env_name: "nsls2-collection-2021-2.2-py39"
+conda_env_file: "nsls2-collection-2021-2.2-py39-env.yml"
 conda_binary: "mamba"
 python_version: "3.9"
 pkg_name: ""
@@ -15,13 +15,13 @@ docker_upload:
   - ghcr
   - dockerhub
   # - quay
-zenodo_upload: "no"
+zenodo_upload: "yes"
 zenodo_metadata:
   metadata:
     title: "NSLS-II collection conda environment"
     upload_type: "software"
     description: "NSLS-II collection conda environment"
-    version: 2021-2.0
+    version: 2021-2.2
     creators:
       - name: Rakitin, Maksim
         affiliation: "Brookhaven National Laboratory"

--- a/configs/nsls2-collection-py39.yml
+++ b/configs/nsls2-collection-py39.yml
@@ -15,7 +15,7 @@ docker_upload:
   - ghcr
   - dockerhub
   # - quay
-zenodo_upload: "yes"
+zenodo_upload: "no"
 zenodo_metadata:
   metadata:
     title: "NSLS-II collection conda environment"

--- a/configs/nsls2-collection.yml
+++ b/configs/nsls2-collection.yml
@@ -1,6 +1,6 @@
 docker_image: "quay.io/condaforge/linux-anvil-comp7:latest"
-env_name: "nsls2-collection-2021-2.1"
-conda_env_file: "nsls2-collection-2021-2.1-env.yml"
+env_name: "nsls2-collection-2021-2.2"
+conda_env_file: "nsls2-collection-2021-2.2-env.yml"
 conda_binary: "mamba"
 python_version: "3.7"
 pkg_name: ""
@@ -15,13 +15,13 @@ docker_upload:
   - ghcr
   - dockerhub
   # - quay
-zenodo_upload: "no"
+zenodo_upload: "yes"
 zenodo_metadata:
   metadata:
     title: "NSLS-II collection conda environment"
     upload_type: "software"
     description: "NSLS-II collection conda environment"
-    version: 2021-2.0
+    version: 2021-2.2
     creators:
       - name: Rakitin, Maksim
         affiliation: "Brookhaven National Laboratory"

--- a/configs/nsls2-collection.yml
+++ b/configs/nsls2-collection.yml
@@ -15,7 +15,7 @@ docker_upload:
   - ghcr
   - dockerhub
   # - quay
-zenodo_upload: "yes"
+zenodo_upload: "no"
 zenodo_metadata:
   metadata:
     title: "NSLS-II collection conda environment"

--- a/envs/nsls2-collection-2021-2.2-env.yml
+++ b/envs/nsls2-collection-2021-2.2-env.yml
@@ -1,0 +1,166 @@
+name: nsls2-collection-2021-2.1
+channels:
+  - conda-forge
+dependencies:
+  #***************************************************************************#
+  #                                                                           #
+  #            Dependencies from the `nsls2-analysis` metapackage             #
+  #                                                                           #
+  #***************************************************************************#
+  - python >=3.7,<3.8
+  - amostra <=1.0
+  - ansiwrap
+  - area-detector-handlers
+  - arvpyf
+  - attrs >=18.0
+  - black
+  - bluesky >=1.6.7
+  - bluesky-kafka  # [not win]
+  - bluesky-live
+  - boto3
+  - chxtools
+  - conda-pack
+  - csxtools
+  # TODO: check that the latest 'distributed' package works with the latest
+  # 'dask' package. Currently we are pinning the both libraries to have the
+  # same version.
+  - dask  # ={{ dask_pin }}
+  - databroker >=1.2.0
+  - databroker-pack
+  - distributed  # ={{ dask_pin }}
+  - doi2bib
+  # - edrixs
+  - eiger-io
+  - event-model >=1.17.0
+  - fabio
+  - ffmpeg >=4.0
+  - flake8
+  - globus-sdk
+  - graphviz
+  - grid-strategy
+  - h5py >=2.9.0
+  - hdf5-external-filter-plugins-bitshuffle
+  - hdf5-external-filter-plugins-lz4
+  - hxntools >=0.5
+  - igor
+  - inflection
+  # - intel-openmp ={{ mkl_pin }}
+  - ipykernel
+  - ipympl >=0.1.1
+  - ipython >=7.20.0
+  - ipywidgets >=7.2.1
+  - isort
+  - ispyb
+  - isstools
+  - jedi
+  - jupyter
+  - jupyterlab
+  - legacy-suitcase
+  - line_profiler
+  - lixtools
+  - lmfit
+  - lxml
+  - matplotlib >=3.1.0,!=3.3
+  - memory_profiler
+  - mendeleev
+  # - mkl ={{ mkl_pin }}
+  - modestimage
+  - napari >=0.3.7
+  - natsort
+  - netcdf4
+  - nexpy >=0.12.7
+  - nodejs
+  - nsls2-detector-handlers >=0.0.2
+  - nslsii >=0.1.1
+  - numexpr
+  - numpy >=1.14.0
+  - oct2py
+  - opencv
+  - openpyxl
+  - ophyd >=1.6.0
+  - papermill
+  - pdfstream
+  - peakutils
+  - periodictable
+  - photutils
+  - pillow
+  - pocl  # needed by pyopencl, used by the `xrt` package
+  - py4xs
+  - pycentroids  # [not win]
+  - pyepics >=3.4.2
+  - pyfai
+  - pyfftw
+  - pymongo >=3.7
+  - pypdf2
+  - pyqt >=5.9.0
+  - pyqtgraph
+  - pystackreg
+  - python
+  - python-graphviz
+  - pyxrf >=1.0.5
+  - pyzbar  # [not win]
+  - qt >=5.9.0
+  - redis-py
+  - reportlab
+  - requests
+  - sasview
+  - scikit-beam >=0.0.23
+  - scikit-learn
+  - scipy
+  - sixtools
+  - slackclient
+  - suitcase-csv
+  - suitcase-json-metadata
+  - suitcase-jsonl
+  - suitcase-mongo  # >=0.3.0 # remove the pin until https://github.com/conda-forge/suitcase-mongo-feedstock/pull/5 is merged
+  - suitcase-msgpack
+  - suitcase-specfile
+  - suitcase-tiff
+  - suitcase-utils
+  - sympy
+  - toml
+  - tomopy
+  - tornado
+  - tqdm
+  - tzlocal >=1.5
+  - xlrd
+  - xlwt
+  - xpdan
+  - xray-vision
+  - xraylarch
+  - zbar  # missing dependency of pyzbar, see https://github.com/conda-forge/pyzbar-feedstock/pull/2
+  # Simulation packages:
+  - oscars
+  - shadow3
+  - srwpy
+  - xrt
+  #***************************************************************************#
+  #                                                                           #
+  #            Dependencies from the `nsls2-collection` metapackage           #
+  #                                                                           #
+  #***************************************************************************#
+  - bloptools
+  - bluesky-darkframes
+  - caproto
+  - happi
+  - nslsii >=0.1.3
+  - pexpect
+  # - pydm
+  - pyepics >=3.4.2
+  - pyolog >=4.4.0
+  - pyserial
+  - python-confluent-kafka  # [not win]
+  - redis-py
+  - simple-pid
+  - slack-sdk
+  # Beamline-specific packages
+  - hklpy  # [linux]
+  - hxnfly
+  - ppmac
+  - xpdacq
+  # Debugging tools:
+  - hunter
+  - logging_tree
+  # Profiling tools:
+  - line_profiler
+  - pyinstrument

--- a/envs/nsls2-collection-2021-2.2-env.yml
+++ b/envs/nsls2-collection-2021-2.2-env.yml
@@ -1,4 +1,4 @@
-name: nsls2-collection-2021-2.1
+name: nsls2-collection-2021-2.2
 channels:
   - conda-forge
 dependencies:
@@ -56,7 +56,6 @@ dependencies:
   - jupyter
   - jupyterlab
   - legacy-suitcase
-  - line_profiler
   - lixtools
   - lmfit
   - lxml
@@ -71,13 +70,13 @@ dependencies:
   - nexpy >=0.12.7
   - nodejs
   - nsls2-detector-handlers >=0.0.2
-  - nslsii >=0.1.1
+  - nslsii >=0.2.1
   - numexpr
   - numpy >=1.14.0
   - oct2py
   - opencv
   - openpyxl
-  - ophyd >=1.6.0
+  - ophyd >=1.6.2
   - papermill
   - pdfstream
   - peakutils
@@ -128,7 +127,7 @@ dependencies:
   - xpdan
   - xray-vision
   - xraylarch
-  - zbar  # missing dependency of pyzbar, see https://github.com/conda-forge/pyzbar-feedstock/pull/2
+  - zbar  # dependency of pyzbar
   # Simulation packages:
   - oscars
   - shadow3
@@ -143,14 +142,11 @@ dependencies:
   - bluesky-darkframes
   - caproto
   - happi
-  - nslsii >=0.1.3
   - pexpect
   # - pydm
-  - pyepics >=3.4.2
   - pyolog >=4.4.0
   - pyserial
   - python-confluent-kafka  # [not win]
-  - redis-py
   - simple-pid
   - slack-sdk
   # Beamline-specific packages

--- a/envs/nsls2-collection-2021-2.2-py39-env.yml
+++ b/envs/nsls2-collection-2021-2.2-py39-env.yml
@@ -1,0 +1,166 @@
+name: nsls2-collection-2021-2.0
+channels:
+  - conda-forge
+dependencies:
+  #***************************************************************************#
+  #                                                                           #
+  #            Dependencies from the `nsls2-analysis` metapackage             #
+  #                                                                           #
+  #***************************************************************************#
+  - python >=3.9,<3.10
+  - amostra <=1.0
+  - ansiwrap
+  - area-detector-handlers
+  - arvpyf
+  - attrs >=18.0
+  - black
+  - bluesky >=1.6.7
+  - bluesky-kafka  # [not win]
+  - bluesky-live
+  - boto3
+  - chxtools
+  - conda-pack
+  - csxtools
+  # TODO: check that the latest 'distributed' package works with the latest
+  # 'dask' package. Currently we are pinning the both libraries to have the
+  # same version.
+  - dask  # ={{ dask_pin }}
+  - databroker >=1.2.0
+  - databroker-pack
+  - distributed  # ={{ dask_pin }}
+  - doi2bib
+  # - edrixs
+  - eiger-io
+  - event-model >=1.17.0
+  - fabio
+  - ffmpeg >=4.0
+  - flake8
+  - globus-sdk
+  - graphviz
+  - grid-strategy
+  - h5py >=2.9.0
+  - hdf5-external-filter-plugins-bitshuffle
+  - hdf5-external-filter-plugins-lz4
+  - hxntools >=0.5
+  - igor
+  - inflection
+  # - intel-openmp ={{ mkl_pin }}
+  - ipykernel
+  - ipympl >=0.1.1
+  - ipython >=7.20.0
+  - ipywidgets >=7.2.1
+  - isort
+  - ispyb
+  - isstools
+  - jedi
+  - jupyter
+  - jupyterlab
+  - legacy-suitcase
+  - line_profiler
+  - lixtools
+  - lmfit
+  - lxml
+  - matplotlib >=3.1.0,!=3.3
+  - memory_profiler
+  - mendeleev
+  # - mkl ={{ mkl_pin }}
+  - modestimage
+  - napari >=0.3.7
+  - natsort
+  - netcdf4
+  - nexpy >=0.12.7
+  - nodejs
+  - nsls2-detector-handlers >=0.0.2
+  - nslsii >=0.1.1
+  - numexpr
+  - numpy >=1.14.0
+  - oct2py
+  - opencv
+  - openpyxl
+  - ophyd >=1.6.0
+  - papermill
+  - pdfstream
+  - peakutils
+  - periodictable
+  - photutils
+  - pillow
+  - pocl  # needed by pyopencl, used by the `xrt` package
+  - py4xs
+  - pycentroids  # [not win]
+  - pyepics >=3.4.2
+  - pyfai
+  - pyfftw
+  - pymongo >=3.7
+  - pypdf2
+  - pyqt >=5.9.0
+  - pyqtgraph
+  - pystackreg
+  - python
+  - python-graphviz
+  - pyxrf >=1.0.5
+  - pyzbar  # [not win]
+  - qt >=5.9.0
+  - redis-py
+  - reportlab
+  - requests
+  - sasview
+  - scikit-beam >=0.0.23
+  - scikit-learn
+  - scipy
+  - sixtools
+  - slackclient
+  - suitcase-csv
+  - suitcase-json-metadata
+  - suitcase-jsonl
+  - suitcase-mongo  # >=0.3.0 # remove the pin until https://github.com/conda-forge/suitcase-mongo-feedstock/pull/5 is merged
+  - suitcase-msgpack
+  - suitcase-specfile
+  - suitcase-tiff
+  - suitcase-utils
+  - sympy
+  - toml
+  - tomopy
+  - tornado
+  - tqdm
+  - tzlocal >=1.5
+  - xlrd
+  - xlwt
+  - xpdan
+  - xray-vision
+  - xraylarch
+  - zbar  # missing dependency of pyzbar, see https://github.com/conda-forge/pyzbar-feedstock/pull/2
+  # Simulation packages:
+  - oscars
+  - shadow3
+  - srwpy
+  - xrt
+  #***************************************************************************#
+  #                                                                           #
+  #            Dependencies from the `nsls2-collection` metapackage           #
+  #                                                                           #
+  #***************************************************************************#
+  - bloptools
+  - bluesky-darkframes
+  - caproto
+  - happi
+  - nslsii >=0.1.3
+  - pexpect
+  # - pydm
+  - pyepics >=3.4.2
+  - pyolog >=4.4.0
+  - pyserial
+  - python-confluent-kafka  # [not win]
+  - redis-py
+  - simple-pid
+  - slack-sdk
+  # Beamline-specific packages
+  - hklpy  # [linux]
+  - hxnfly
+  - ppmac
+  - xpdacq
+  # Debugging tools:
+  - hunter
+  - logging_tree
+  # Profiling tools:
+  - line_profiler
+  - pyinstrument

--- a/envs/nsls2-collection-2021-2.2-py39-env.yml
+++ b/envs/nsls2-collection-2021-2.2-py39-env.yml
@@ -1,4 +1,4 @@
-name: nsls2-collection-2021-2.0
+name: nsls2-collection-2021-2.2-py39
 channels:
   - conda-forge
 dependencies:
@@ -56,7 +56,6 @@ dependencies:
   - jupyter
   - jupyterlab
   - legacy-suitcase
-  - line_profiler
   - lixtools
   - lmfit
   - lxml
@@ -71,13 +70,13 @@ dependencies:
   - nexpy >=0.12.7
   - nodejs
   - nsls2-detector-handlers >=0.0.2
-  - nslsii >=0.1.1
+  - nslsii >=0.2.1
   - numexpr
   - numpy >=1.14.0
   - oct2py
   - opencv
   - openpyxl
-  - ophyd >=1.6.0
+  - ophyd >=1.6.2
   - papermill
   - pdfstream
   - peakutils
@@ -128,7 +127,7 @@ dependencies:
   - xpdan
   - xray-vision
   - xraylarch
-  - zbar  # missing dependency of pyzbar, see https://github.com/conda-forge/pyzbar-feedstock/pull/2
+  - zbar  # dependency of pyzbar
   # Simulation packages:
   - oscars
   - shadow3
@@ -143,14 +142,11 @@ dependencies:
   - bluesky-darkframes
   - caproto
   - happi
-  - nslsii >=0.1.3
   - pexpect
   # - pydm
-  - pyepics >=3.4.2
   - pyolog >=4.4.0
   - pyserial
   - python-confluent-kafka  # [not win]
-  - redis-py
   - simple-pid
   - slack-sdk
   # Beamline-specific packages

--- a/render.py
+++ b/render.py
@@ -19,6 +19,7 @@ def read_params(config_file):
     params.setdefault("docker_upload", ["dockerhub", "ghcr", "quay"])
     params.setdefault("conda_binary", "conda")
     params.setdefault("conda_env_file", None)
+    params.setdefault("config_file", config_file)
 
     zenodo_metadata_present = params.pop(
         "zenodo_metadata", None

--- a/templates/runner.sh.j2
+++ b/templates/runner.sh.j2
@@ -74,6 +74,6 @@ python3 zenodo_uploader.py -f ${artifacts_dir}/${env_name}.tar.gz \
                            -f ${artifacts_dir}/${env_name}-md5sum.txt \
                            -f Dockerfile \
                            -f ${0} \
-                           -c configs/${env_name}.yml \
+                           -c ${config_file} \
                            --publish
 {% endif %}

--- a/zenodo_uploader.py
+++ b/zenodo_uploader.py
@@ -4,9 +4,10 @@ import os
 import textwrap
 import traceback
 from urllib.parse import urlencode
-from tabulate import tabulate
+
 import requests
 import yaml
+from tabulate import tabulate
 
 
 def search_for_deposition(
@@ -96,7 +97,14 @@ def search_for_deposition(
         )
         data_dict["dates"].append(meta["publication_date"])
 
-    print(tabulate(data_dict, headers="keys", showindex=showindex))
+    if showindex:
+        counter = range(1, len(records) + 1)
+    else:
+        counter = False
+
+    print(
+        tabulate(data_dict, headers="keys", showindex=counter, tablefmt="grid")
+    )
 
     if not depositions:
         print(f"No records found for search: '{title}'")


### PR DESCRIPTION
Updates:
- Add a missing `zbar` dependency of `pyzbar` (see https://github.com/conda-forge/pyzbar-feedstock/pull/2#issuecomment-899646563).
- Minimum `ophyd` pin is v1.6.2.
- Minimum `nslsii` pin is v0.2.1.
- Remove duplicates from the env files.
- Fix missing vars in the CI configs.
- Update the table with found Zenodo records.